### PR TITLE
Added development evironment via docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+version: '3'
+services:
+  syslog-ng:
+    image: balabit/syslog-ng
+    volumes:
+      - /tmp/syslog-ng:/tmp/syslog-ng
+      - ./etc/syslog-ng/syslog-ng.conf:/etc/syslog-ng/syslog-ng.conf
+  zookeeper:
+    image: confluentinc/cp-zookeeper:4.1.1
+    ports:
+      - 32181:32181
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 32181
+      ZOOKEEPER_TICK_TIME: 2000
+    extra_hosts:
+      - "localhost: 127.0.0.1"
+  kafka:
+    image: confluentinc/cp-kafka:4.1.1
+    ports:
+      - 29092:29092
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29093,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    extra_hosts:
+      - "localhost: 127.0.0.1"
+  schema-registry:
+    image: confluentinc/cp-schema-registry:4.1.1
+    depends_on:
+      - zookeeper
+      - kafka
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:32181'
+  northstar-parse:
+    depends_on:
+      - syslog-ng
+      - kafka
+      - schema-registry
+    environment:
+      BOOTSTRAP_SERVERS: kafka:29093
+      SCHEMA_REGISTRY_URL: http://schema-registry:8081
+    build:
+      context: parse
+    volumes:
+      - /tmp/syslog-ng:/tmp/syslog-ng
+  northstar-http:
+    ports:
+      - 8080:8080
+    depends_on:
+      - syslog-ng
+      - kafka
+    environment:
+      BOOTSTRAP_SERVERS: kafka:29093
+    build:
+      context: http

--- a/http/Dockerfile
+++ b/http/Dockerfile
@@ -1,0 +1,5 @@
+FROM java:8
+
+COPY target/scala-2.12/northstar-http-assembly-0.1.0-SNAPSHOT.jar /opt/northstar/lib/
+
+CMD java -Dakka.kafka.producer.kafka-clients.bootstrap.servers="$BOOTSTRAP_SERVERS" -cp "/opt/northstar/lib/*" io.jask.svc.northstar.IngestService

--- a/parse/Dockerfile
+++ b/parse/Dockerfile
@@ -1,0 +1,7 @@
+FROM java:8
+
+COPY target/scala-2.12/northstar-parse-assembly-0.1.0-SNAPSHOT.jar /opt/northstar/lib/
+
+CMD java -Dkafka.bootstrap.servers="$BOOTSTRAP_SERVERS" \
+         -Dkafka.schema.registry.url="$SCHEMA_REGISTRY_URL" \
+         -cp "/opt/northstar/lib/*" io.jask.svc.northstar.ParseService


### PR DESCRIPTION
Caveat: this was tested against the trident-3517 branch since http and parse don't play nice in current master. 

As config values change, we will need to change the overrrides in the dockerfiles as well (right now bootstrap servers and schema registry won't work in both master without changing them to the current form.